### PR TITLE
Remove the Plausible tracking code from the template

### DIFF
--- a/_templates/base.html
+++ b/_templates/base.html
@@ -48,10 +48,7 @@
 
   <!-- Main CSS stylesheet -->
   <link rel="stylesheet" href="{{ "css/style.css"|relative_to(page.path) }}">
-
-  <!-- Plausible analytics for anonymous usage statistics -->
-  <script defer data-domain="compgeolab.org" src="https://plausible.io/js/plausible.js"></script>
-
+  
   {%- block extrahead %}{% endblock %}
 
 </head>


### PR DESCRIPTION
The tracking code for the compgeolab.org domain was still in place, causing some traffic for this website to show up
in my analytics 🙂